### PR TITLE
docs: development cycle & build process guide (EN + SR Cyrillic)

### DIFF
--- a/doc/manuals/development-cycle-guide.md
+++ b/doc/manuals/development-cycle-guide.md
@@ -1,0 +1,120 @@
+# Development cycle & build process — team guide
+
+This document describes how building and publishing Docker images works after the move to the
+new system. It applies to all migrated services (MoUser, MoSafewatch, MoCompany, MoLlm, …) —
+the workflow is the same; only the image name differs.
+
+## Key change
+
+- **A production build is NO LONGER triggered by committing to `application.properties`.**
+- Production is published **only by creating a GitHub Release** on a `vX.Y.Z` tag.
+- The version is no longer maintained by hand in a file — **the git tag is the single source of truth**.
+
+## Build channels
+
+| Channel | Trigger | Docker tags |
+|---------|---------|-------------|
+| **dev** | push to `main` (or `master`) | `dev`, `dev-<version>`, `dev-3`, `dev-3.65` |
+| **feat** | manual (`workflow_dispatch`) from any branch | `feat-<name>` |
+| **rc / staging** | GitHub Release marked *pre-release* on `vX.Y.Z-rc.N` | `rc-<version>-<n>`, `staging` |
+| **prod** | published GitHub Release on `vX.Y.Z` | `prod-X.Y.Z`, `prod`, `prod-3`, `prod-3.65` |
+
+> `dev-<version>` looks like `dev-3.65.4-5-gabc123` (last release + commit count + sha), produced
+> by `git describe`. Before the first `v*` tag exists, it falls back to `dev-<sha>`.
+
+## Versioning — `vX.Y.Z`
+
+- We use **semantic versioning** with a `v` prefix: `v3.65.5`.
+- `X` = major, `Y` = minor, `Z` = patch.
+- A full release tag must be clean semver (`v3.66.2`). Tags like `v3.66.2-beta` published as a
+  **full** release are rejected — use a pre-release flag or a clean tag.
+
+---
+
+## 1. Day-to-day work (dev)
+
+Nothing special — **just push/merge to `main`**. CI automatically:
+- builds and publishes the image with tags `dev`, `dev-<git-describe>`, `dev-3`, `dev-3.65`.
+- derives the version from git (you don't touch `application.properties`).
+
+```bash
+git push origin main
+# → neobeedev/<image>:dev  and  :dev-3.65.4-5-gabc123  and  :dev-3  and  :dev-3.65
+```
+
+## 2. Feature / preview build (to test a branch)
+
+When you're working on a feature branch and want an image you can pull on a dev environment:
+
+**From the command line:**
+```bash
+gh workflow run build-and-push.yml --ref my-branch -f tag=my-feature
+# → neobeedev/<image>:feat-my-feature
+```
+If you omit `-f tag`, the branch name is used (`feat-<branch>`).
+
+**From the GitHub UI:**
+1. Repo → **Actions** → workflow **"Build and Push to DockerHub"**.
+2. **"Run workflow"** button → pick the branch → (optional) enter `tag` → **Run workflow**.
+
+> Note: the "Run workflow" button only appears once a workflow with the `workflow_dispatch`
+> trigger is on the default branch (`main`/`master`).
+>
+> A feature build **does not move** the `dev` / `prod` / `staging` tags — it gets only `feat-<...>`.
+
+## 3. Release candidate / staging
+
+When you want to test a production candidate before it goes to prod:
+
+```bash
+gh release create v3.65.6-rc.1 --prerelease --title "3.65.6-rc.1" --notes "..."
+# → neobeedev/<image>:rc-3.65.6-1  +  :staging
+```
+- `staging` always points to the latest pre-release — handy for deploying to a staging environment.
+- It **does not touch** the production tags.
+- When the candidate is good, promote it with a full release (step 4).
+
+## 4. Production release
+
+```bash
+gh release create v3.65.6 --title "3.65.6" --notes "..."
+# → neobeedev/<image>:prod-3.65.6  +  :prod  :prod-3  :prod-3.65
+```
+Or via the GitHub UI: **Releases** → **Draft a new release** → tag `v3.65.6` → **Publish release**.
+
+- `prod` / `prod-3` / `prod-3.65` move only if this is the **newest** version in that group
+  (see "Hotfix" below) — so a hotfix on an older line never drags `prod` backward.
+
+## 5. Hotfix from a released tag
+
+When you need an urgent fix on an already-published version, without pulling in everything that
+has since landed on `main`:
+
+```bash
+git checkout -b hotfix/3.65.7 v3.65.6      # branch FROM the release tag
+# make the fix + commit
+git push -u origin hotfix/3.65.7
+gh release create v3.65.7 --target hotfix/3.65.7 --title "3.65.7" --notes "hotfix"
+#   then PR hotfix/3.65.7 → main so the fix isn't lost
+```
+- `--target` points the new tag at the hotfix branch tip.
+- If `main` has already moved to a newer line (e.g. 3.66.x), the hotfix publishes only
+  `prod-3.65.7` + `prod-3.65` and does **not** move `prod` / `prod-3` backward.
+
+---
+
+## Important rules & common mistakes
+
+- **Pushing a bare tag does nothing.** Production goes **only** through a published GitHub
+  Release. `git push --tags` by itself does not trigger a build.
+- **The tag must point to a commit that already contains the new workflow.** If you create a
+  release on an old commit (from before the migration), the build will NOT start. Create the
+  release on a tag tied to the current `main` (`--target main`).
+- **A full release must be clean semver** (`vX.Y.Z`). For candidates, use `--prerelease` with
+  an `-rc.N` suffix.
+- **You don't touch the version in `application.properties`** — CI passes it via `-D` parameters.
+  The `quarkus.application.version=dev` value in the file is only a default for local builds.
+- **The version printed at application startup** is correct because it is baked into the image
+  at build time (prod → `3.65.6`, dev → `3.65.4-5-gabc123`, local → `dev`).
+- **`dev-3` / `dev-3.65`** are floating tags pointing to the latest dev on that major/minor line;
+  they are derived from the last release tag, not written by hand.

--- a/doc/manuals/razvojni-ciklus-uputstvo.md
+++ b/doc/manuals/razvojni-ciklus-uputstvo.md
@@ -1,0 +1,120 @@
+# Развојни циклус и build процес — упутство за тим
+
+Овај документ описује како функционише build и објављивање Docker image-а након
+преласка на нови систем. Важи за све мигриране сервисе (MoUser, MoSafewatch, MoCompany,
+MoLlm, …) — workflow је исти, разликује се само име image-а.
+
+## Кључна промена
+
+- **Продукциони build се више НЕ покреће commit-ом у `application.properties`.**
+- Продукција се објављује **искључиво креирањем GitHub Release-а** на `vX.Y.Z` таг-у.
+- Верзија се више не одржава ручно у фајлу — **једини извор истине је git таг**.
+
+## Канали build-а
+
+| Канал | Када се покреће | Docker тагови |
+|-------|-----------------|---------------|
+| **dev** | push на `main` (или `master`) | `dev`, `dev-<верзија>`, `dev-3`, `dev-3.65` |
+| **feat** | ручно (`workflow_dispatch`) са било које гране | `feat-<назив>` |
+| **rc / staging** | GitHub Release означен као *pre-release* на `vX.Y.Z-rc.N` | `rc-<верзија>-<n>`, `staging` |
+| **prod** | објављен GitHub Release на `vX.Y.Z` | `prod-X.Y.Z`, `prod`, `prod-3`, `prod-3.65` |
+
+> `dev-<верзија>` је облика `dev-3.65.4-5-gabc123` (последњи release + број commit-а + sha),
+> добијен преко `git describe`. Пре првог `v*` тага користи се `dev-<sha>`.
+
+## Верзионисање — `vX.Y.Z`
+
+- Користимо **семантичко верзионисање** са префиксом `v`: `v3.65.5`.
+- `X` = major, `Y` = minor, `Z` = patch.
+- Пун release таг мора бити чист semver (`v3.66.2`). Тагови типа `v3.66.2-beta` као **пун**
+  release биће одбијени — користи pre-release ознаку или чист таг.
+
+---
+
+## 1. Свакодневни рад (dev)
+
+Ништа посебно — **само push/merge на `main`**. CI аутоматски:
+- направи и објави image са таговима `dev`, `dev-<git-describe>`, `dev-3`, `dev-3.65`.
+- верзију извуче из git-а (не дираш `application.properties`).
+
+```bash
+git push origin main
+# → neobeedev/<image>:dev  и  :dev-3.65.4-5-gabc123  и  :dev-3  и  :dev-3.65
+```
+
+## 2. Feature / preview build (за тестирање гране)
+
+Када радиш на feature грани и желиш image који можеш да повучеш на dev окружење:
+
+**Из командне линије:**
+```bash
+gh workflow run build-and-push.yml --ref naziv-grane -f tag=moj-feature
+# → neobeedev/<image>:feat-moj-feature
+```
+Ако изоставиш `-f tag`, користи се назив гране (`feat-<grana>`).
+
+**Из GitHub UI:**
+1. Repo → **Actions** → workflow **„Build and Push to DockerHub“**.
+2. Дугме **„Run workflow“** → изабери грану → (опционо) упиши `tag` → **Run workflow**.
+
+> Напомена: дугме „Run workflow“ се појављује тек када је workflow са `workflow_dispatch`
+> тригер-ом на подразумеваној грани (`main`/`master`).
+>
+> Feature build **не помера** `dev` / `prod` / `staging` тагове — добија само `feat-<...>`.
+
+## 3. Release кандидат / staging
+
+Када желиш да тестираш кандидат за продукцију пре него што оде у prod:
+
+```bash
+gh release create v3.65.6-rc.1 --prerelease --title "3.65.6-rc.1" --notes "..."
+# → neobeedev/<image>:rc-3.65.6-1  +  :staging
+```
+- `staging` увек показује на најновији pre-release — згодно за деплој на staging окружење.
+- **Не дира** продукционе тагове.
+- Када је кандидат добар, промовишеш га пуним release-ом (корак 4).
+
+## 4. Продукциони release
+
+```bash
+gh release create v3.65.6 --title "3.65.6" --notes "..."
+# → neobeedev/<image>:prod-3.65.6  +  :prod  :prod-3  :prod-3.65
+```
+Или кроз GitHub UI: **Releases** → **Draft a new release** → таг `v3.65.6` → **Publish release**.
+
+- `prod` / `prod-3` / `prod-3.65` се померају само ако је ово **најновија** верзија у тој
+  групи (види „Hotfix“ испод) — тако hotfix на старој линији не враћа `prod` уназад.
+
+## 5. Hotfix са објављеног тага
+
+Када треба хитна исправка на већ објављеној верзији, без повлачења свега што је у
+међувремену стигло на `main`:
+
+```bash
+git checkout -b hotfix/3.65.7 v3.65.6      # грана ОД release тага
+# направи исправку + commit
+git push -u origin hotfix/3.65.7
+gh release create v3.65.7 --target hotfix/3.65.7 --title "3.65.7" --notes "hotfix"
+#   затим PR hotfix/3.65.7 → main да се исправка не изгуби
+```
+- `--target` веже нови таг за врх hotfix гране.
+- Ако је `main` већ отишао на новију линију (нпр. 3.66.x), hotfix објављује само
+  `prod-3.65.7` + `prod-3.65` и **не** помера `prod` / `prod-3` уназад.
+
+---
+
+## Важна правила и честе грешке
+
+- **Празан push тага не ради ништа.** Продукција иде **само** преко објављеног GitHub
+  Release-а. `git push --tags` сам по себи не покреће build.
+- **Таг мора да показује на commit који већ садржи нови workflow.** Ако направиш release
+  на старом commit-у (од пре миграције), build се НЕЋЕ покренути. Прави release на таг-у
+  везаном за актуелни `main` (`--target main`).
+- **Пун release мора бити чист semver** (`vX.Y.Z`). За кандидате користи `--prerelease`
+  и `-rc.N` суфикс.
+- **Верзију не дираш у `application.properties`** — CI је прослеђује преко `-D` параметара.
+  Вредност `quarkus.application.version=dev` у фајлу је само default за локални build.
+- **Верзија која се исписује при старту апликације** је тачна јер је „упечена“ у image
+  током build-а (prod → `3.65.6`, dev → `3.65.4-5-gabc123`, локално → `dev`).
+- **`dev-3` / `dev-3.65`** су „покретни“ тагови који показују на најновији dev на тој
+  major/minor линији; изведени су из последњег release тага, не пишу се ручно.


### PR DESCRIPTION
Adds the team guide for the new release-build flow under `doc/manuals/`:

- `development-cycle-guide.md` — English
- `razvojni-ciklus-uputstvo.md` — Serbian (Cyrillic)

Covers the four build channels (dev / feat / rc-staging / prod), `vX.Y.Z` versioning, step-by-step for daily dev, feature/preview builds, release candidates, production releases, and hotfixes, plus common pitfalls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)