### PR TITLE
docs: GHCR registry routing + pull/setup section

### DIFF
--- a/doc/manuals/development-cycle-guide.md
+++ b/doc/manuals/development-cycle-guide.md
@@ -12,15 +12,58 @@ the workflow is the same; only the image name differs.
 
 ## Build channels
 
-| Channel | Trigger | Docker tags |
-|---------|---------|-------------|
-| **dev** | push to `main` (or `master`) | `dev`, `dev-<version>`, `dev-3`, `dev-3.65` |
-| **feat** | manual (`workflow_dispatch`) from any branch | `feat-<name>` |
-| **rc / staging** | GitHub Release marked *pre-release* on `vX.Y.Z-rc.N` | `rc-<version>-<n>`, `staging` |
-| **prod** | published GitHub Release on `vX.Y.Z` | `prod-X.Y.Z`, `prod`, `prod-3`, `prod-3.65` |
+| Channel | Trigger | Registry | Image tags |
+|---------|---------|----------|------------|
+| **dev** | push to `main` (or `master`) | `ghcr.io/estehdev` (+ DockerHub `neobeedev`, temporary) | `dev`, `dev-<version>`, `dev-3`, `dev-3.65` |
+| **feat** | manual (`workflow_dispatch`) from any branch | `ghcr.io/estehdev` | `feat-<name>` |
+| **rc / staging** | GitHub Release marked *pre-release* on `vX.Y.Z-rc.N` | `ghcr.io/estehdev` | `rc-<version>-<n>`, `staging` |
+| **prod** | published GitHub Release on `vX.Y.Z` | DockerHub `neobeedev` | `prod-X.Y.Z`, `prod`, `prod-3`, `prod-3.65` |
 
 > `dev-<version>` looks like `dev-3.65.4-5-gabc123` (last release + commit count + sha), produced
 > by `git describe`. Before the first `v*` tag exists, it falls back to `dev-<sha>`.
+
+## Where images are published (registries)
+
+- **Production** images go to **DockerHub** (`neobeedev/<image>`) — unchanged.
+- **Everything else** (dev / feat / rc-staging) now goes to **GitHub Container Registry (GHCR)**:
+  `ghcr.io/estehdev/<image>`.
+- **Transition:** for now, **dev** images are *also* mirrored to DockerHub
+  (`neobeedev/<image>:dev*`) so existing dev-environment references keep working. Once every
+  dev environment pulls from GHCR, that mirror is removed and dev will live on GHCR only.
+
+> Rolled out per service (MoSafewatch first). Until a given service's workflow is updated, all of
+> its images still go to DockerHub.
+
+### Pulling images from GHCR
+
+GHCR is **not** DockerHub — your DockerHub credentials do not work for it. To pull an image you
+need a GitHub token with the `read:packages` scope:
+
+1. Create a Personal Access Token (classic): GitHub → **Settings → Developer settings →
+   Personal access tokens → Tokens (classic) → Generate new token**, tick **`read:packages`**.
+2. Log in once on the machine/environment that pulls:
+   ```bash
+   echo <TOKEN> | docker login ghcr.io -u <github-username> --password-stdin
+   ```
+3. Pull as usual:
+   ```bash
+   docker pull ghcr.io/estehdev/<image>:dev
+   ```
+
+For a Kubernetes pull secret, use the same token:
+```bash
+kubectl create secret docker-registry ghcr \
+  --docker-server=ghcr.io \
+  --docker-username=<github-username> \
+  --docker-password=<TOKEN>
+```
+
+**Package visibility:** the first push creates the package as **private**, auto-linked to its repo.
+If a package should be pullable without authentication, an org admin sets it public:
+**Org → Packages → `<image>` → Package settings → Change visibility**.
+
+> **Pushing from CI needs no setup** — the workflow authenticates to GHCR with the built-in
+> `GITHUB_TOKEN` (the job has `packages: write`). The notes above are only for *pulling*.
 
 ## Versioning — `vX.Y.Z`
 

--- a/doc/manuals/razvojni-ciklus-uputstvo.md
+++ b/doc/manuals/razvojni-ciklus-uputstvo.md
@@ -12,15 +12,58 @@ MoLlm, …) — workflow је исти, разликује се само име 
 
 ## Канали build-а
 
-| Канал | Када се покреће | Docker тагови |
-|-------|-----------------|---------------|
-| **dev** | push на `main` (или `master`) | `dev`, `dev-<верзија>`, `dev-3`, `dev-3.65` |
-| **feat** | ручно (`workflow_dispatch`) са било које гране | `feat-<назив>` |
-| **rc / staging** | GitHub Release означен као *pre-release* на `vX.Y.Z-rc.N` | `rc-<верзија>-<n>`, `staging` |
-| **prod** | објављен GitHub Release на `vX.Y.Z` | `prod-X.Y.Z`, `prod`, `prod-3`, `prod-3.65` |
+| Канал | Када се покреће | Регистри | Тагови image-а |
+|-------|-----------------|----------|----------------|
+| **dev** | push на `main` (или `master`) | `ghcr.io/estehdev` (+ DockerHub `neobeedev`, привремено) | `dev`, `dev-<верзија>`, `dev-3`, `dev-3.65` |
+| **feat** | ручно (`workflow_dispatch`) са било које гране | `ghcr.io/estehdev` | `feat-<назив>` |
+| **rc / staging** | GitHub Release означен као *pre-release* на `vX.Y.Z-rc.N` | `ghcr.io/estehdev` | `rc-<верзија>-<n>`, `staging` |
+| **prod** | објављен GitHub Release на `vX.Y.Z` | DockerHub `neobeedev` | `prod-X.Y.Z`, `prod`, `prod-3`, `prod-3.65` |
 
 > `dev-<верзија>` је облика `dev-3.65.4-5-gabc123` (последњи release + број commit-а + sha),
 > добијен преко `git describe`. Пре првог `v*` тага користи се `dev-<sha>`.
+
+## Где се објављују image-и (регистри)
+
+- **Продукциони** image-и иду на **DockerHub** (`neobeedev/<image>`) — без промене.
+- **Све остало** (dev / feat / rc-staging) сада иде на **GitHub Container Registry (GHCR)**:
+  `ghcr.io/estehdev/<image>`.
+- **Прелаз:** за сада се **dev** image-и *такође* копирају на DockerHub
+  (`neobeedev/<image>:dev*`) да би постојеће референце на dev окружењима наставиле да раде.
+  Када сва dev окружења буду повлачила са GHCR-а, то копирање се уклања и dev остаје само на GHCR.
+
+> Уводи се сервис по сервис (прво MoSafewatch). Док се workflow одређеног сервиса не ажурира,
+> сви његови image-и и даље иду на DockerHub.
+
+### Повлачење image-а са GHCR-а
+
+GHCR **није** DockerHub — твоји DockerHub креденцијали ту не раде. За повлачење image-а треба ти
+GitHub токен са `read:packages` овлашћењем:
+
+1. Направи Personal Access Token (classic): GitHub → **Settings → Developer settings →
+   Personal access tokens → Tokens (classic) → Generate new token**, штиклирај **`read:packages`**.
+2. Улогуј се једном на машини/окружењу које повлачи:
+   ```bash
+   echo <TOKEN> | docker login ghcr.io -u <github-korisnicko-ime> --password-stdin
+   ```
+3. Повлачи као и обично:
+   ```bash
+   docker pull ghcr.io/estehdev/<image>:dev
+   ```
+
+За Kubernetes pull secret користи исти токен:
+```bash
+kubectl create secret docker-registry ghcr \
+  --docker-server=ghcr.io \
+  --docker-username=<github-korisnicko-ime> \
+  --docker-password=<TOKEN>
+```
+
+**Видљивост пакета:** први push прави пакет као **приватан**, аутоматски повезан са својим repo-м.
+Ако пакет треба да буде доступан без аутентикације, админ организације га поставља на јаван:
+**Org → Packages → `<image>` → Package settings → Change visibility**.
+
+> **Push из CI-ја не захтева никакво подешавање** — workflow се аутентикује на GHCR преко
+> уграђеног `GITHUB_TOKEN`-а (job има `packages: write`). Горње напомене важе само за *повлачење*.
 
 ## Верзионисање — `vX.Y.Z`
 


### PR DESCRIPTION
Adds registry routing and a GHCR setup section to the development-cycle guide (EN + SR-Cyrillic), matching the CI change in MoSafewatch PR #18.

- Channels table now has a **Registry** column (prod → DockerHub `neobeedev`; dev/feat/rc → `ghcr.io/estehdev`).
- New **"Where images are published"** section: routing + the temporary dev→DockerHub mirror during the transition.
- New **"Pulling images from GHCR"** section: PAT with `read:packages`, `docker login ghcr.io`, k8s pull secret, package visibility. Notes that CI push needs no setup (built-in `GITHUB_TOKEN`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)